### PR TITLE
Remove duplicate fpack dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "build:es2015": "rm -rf build && cp -R root build && rm -rf build/js && fpack src/index.js -o build/js --transpile '^src' --postprocess 'babel --presets es2015' --postprocess 'uglifyjs -cm' && cp node_modules/babel-polyfill/dist/polyfill.min.js build/js"
   },
   "devDependencies": {
-    "fpack": "0.0.3",
     "babel-polyfill": "^6.26.0",
     "babel-cli": "^6.26.0",
     "babel-preset-env": "^1.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -911,9 +911,9 @@ form-data@~2.1.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
-fpack@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/fpack/-/fpack-0.0.3.tgz#9affcd9d399845a49e423e811ea8693e19260091"
+fpack@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/fpack/-/fpack-0.0.4.tgz#7cd0390ee6559e9a2799f3f236ed312fd7ce5af5"
 
 fs-readdir-recursive@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
An older version of fpack was still being required in the `package.json`, affecting which version was being saved in the `yarn.lock` file.